### PR TITLE
docs(ArkTheme): repo links forked version

### DIFF
--- a/plugins-data/ArkTheme/README.md
+++ b/plugins-data/ArkTheme/README.md
@@ -13,4 +13,4 @@
 
 
 # 致谢
-[Hydrogen Music](https://www.bilibili.com/video/BV1gG4y1c7f4) [(Github)](https://github.com/Kaidesuyo/Hydrogen-Music)
+[Hydrogen Music](https://www.bilibili.com/video/BV1gG4y1c7f4) [(Github)](https://github.com/White-i-LC/Hydrogen-Music-5.0)


### PR DESCRIPTION
status of [current repo](https://api.github.com/repos/Kaidesuyo/Hydrogen-Music) link is 404 there are repo version can be provided