### PR TITLE
Change `secrets.GH_TOKEN` to `secrets.GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/get-star-count.yml
+++ b/.github/workflows/get-star-count.yml
@@ -37,7 +37,7 @@ jobs:
           node update-star-count
         id: node
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: scripts/update-star-count
       - name: 'Commit'
         run: |

--- a/.github/workflows/update-plugins.yml
+++ b/.github/workflows/update-plugins.yml
@@ -39,5 +39,5 @@ jobs:
         run: node update-plugins
         id: node
         env:
-          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: scripts/update-plugins


### PR DESCRIPTION
先换用 github 的 token 了，大概能解决权限问题

betterncm的bot那个号需要验证邮箱[1]还是更新token[2]

[1]:HttpError: At least one email address must be verified to do that.
[2]:fatal: unable to access 'https://github.com/BetterNCM/BetterNCM-Plugins/': The requested URL returned error: 403