### PR TITLE
Add RNP Video Background

### DIFF
--- a/plugins-list/rnp-video-background.json
+++ b/plugins-list/rnp-video-background.json
@@ -1,0 +1,7 @@
+{
+  "name": "RNP Video Background",
+  "repo": "wmgqdavid/BetterNCM-RNP-Video-Background",
+  "branch": "main",
+  "subpath": "/",
+  "author": "wmgqdavid"
+}


### PR DESCRIPTION
## 插件简介

为 RefinedNowPlaying Next 添加可持久化的本地 MP4/WebM 视频背景，并可选精简底部播放控制区。

## 说明

- 当前源仓库版本：`0.1.2`
- 依赖：`RefinedNowPlayingNext`
- 视频挂载于 RNP 原生背景层，保留封面、歌曲信息和正常旋转歌词
- 默认完整保留 RNP 设置、全屏、歌词与全部交互功能
- “精简播放控件”默认关闭；开启后仅隐藏底部播放器、进度、音量和 v3 控件
- 视频成功解码首帧后才切换背景；失败时自动恢复原背景
- 仅通过 BetterNCM 本地文件 API 读取用户选择的视频
- 不发起网络请求，不上传视频、路径或使用数据
- 不切换歌词 Overview/复制模式
- 不修改 `.rnp-lyrics-line` 或 `body.lyric-rotate`
- 自动化检查 11/11 通过

源仓库：https://github.com/wmgqdavid/BetterNCM-RNP-Video-Background