### PR TITLE
Add jp-furigana

### DIFF
--- a/plugins-list/jp-furigana.json
+++ b/plugins-list/jp-furigana.json
@@ -1,0 +1,7 @@
+{
+    "name": "jp-furigana",
+    "repo": "Leleawa/jp-furigana",
+    "branch": "main",
+    "subpath": "/src",
+    "author": "leleawa"
+}


### PR DESCRIPTION
日语歌词振假名 (jp-furigana)

给日语歌词的汉字标注振假名 仓库：https://github.com/Leleawa/jp-furigana

商店里已有 Furigana 和 Furigana-api-fixed，本插件是独立实现，不共用代码. 主要差别：

读音优先取网易云自带的官方音译，而不是查词典。歌手故意改读的地方只有音译是对的, 纯词典方案必然给错。词典（kuromoji + IPADIC）只在该曲没有官方音译时兜底。
不依赖任何第三方服务器，音译走网易云自己的歌词接口，词典随插件打包，切换到「只用词典」即完全离线。
送假名做了对齐（持(も)ち帰(かえ)る 而不是 持ち帰る(もちかえる)），连续汉字跨词的情况用词典的词边界切分。
在网易云 2.10.13 和 3.1.36 上实测。

包体积 15 MB，主要是打包的 IPADIC 词典（17 MB 解压前）